### PR TITLE
Demonstrate A2A delegation tool

### DIFF
--- a/a2a_adk_server.py
+++ b/a2a_adk_server.py
@@ -1,0 +1,115 @@
+"""A2A server exposing a worker agent built with Google ADK."""
+
+import asyncio
+import uvicorn
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
+
+from a2a.server.agent_execution.agent_executor import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events.event_queue import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.agent_execution.simple_request_context_builder import SimpleRequestContextBuilder
+from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
+from a2a.server.events.in_memory_queue_manager import InMemoryQueueManager
+from a2a.server.apps.starlette_app import A2AStarletteApplication
+from a2a.types import (
+    AgentCard,
+    AgentCapabilities,
+    TaskStatus,
+    TaskState,
+    TaskStatusUpdateEvent,
+    TaskArtifactUpdateEvent,
+)
+from a2a.utils import new_task, new_text_artifact
+
+
+def perform_task(detail: str) -> str:
+    """Tool executed by the worker agent."""
+    return f"Task '{detail}' completed."
+
+
+class ADKAgentExecutor(AgentExecutor):
+    """Wrap an ADK LlmAgent for the A2A server."""
+
+    def __init__(self, agent: LlmAgent) -> None:
+        self.agent = agent
+
+    async def execute(self, context: RequestContext, queue: EventQueue) -> None:
+        user_input = context.get_user_input()
+        events = await self.agent.run_async(user_input)
+        text = ""
+        for event in events:
+            if event.content and event.content.parts:
+                part = event.content.parts[0]
+                if hasattr(part, "text"):
+                    text = part.text
+        task = context.current_task or new_task(context.message)
+        queue.enqueue_event(task)
+        queue.enqueue_event(
+            TaskArtifactUpdateEvent(
+                append=False,
+                contextId=task.contextId,
+                taskId=task.id,
+                lastChunk=True,
+                artifact=new_text_artifact(
+                    name="result",
+                    description="Task result",
+                    text=text,
+                ),
+            )
+        )
+        queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                status=TaskStatus(state=TaskState.completed),
+                final=True,
+                contextId=task.contextId,
+                taskId=task.id,
+            )
+        )
+
+    async def cancel(self, context: RequestContext, queue: EventQueue) -> None:
+        queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                status=TaskStatus(state=TaskState.canceled),
+                final=True,
+                contextId=context.context_id,
+                taskId=context.task_id,
+            )
+        )
+
+
+async def main() -> None:
+    worker = LlmAgent(
+        name="worker_agent",
+        description="Handles delegated work.",
+        model=LiteLlm(model="openai/gpt-4o"),
+        instruction="Use perform_task to handle the request.",
+        tools=[perform_task],
+    )
+
+    executor = ADKAgentExecutor(worker)
+    task_store = InMemoryTaskStore()
+    queue_manager = InMemoryQueueManager()
+    handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=task_store,
+        queue_manager=queue_manager,
+        request_context_builder=SimpleRequestContextBuilder(task_store=task_store),
+    )
+    card = AgentCard(
+        name="worker_agent",
+        description="ADK worker agent",
+        capabilities=AgentCapabilities(),
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["text/plain"],
+        url="http://localhost:8000/",
+        version="1.0",
+    )
+    app = A2AStarletteApplication(card, handler)
+    uvicorn.run(app.build(), host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/multi_agent_a2a.py
+++ b/multi_agent_a2a.py
@@ -1,0 +1,82 @@
+"""Demonstrate two ADK agents communicating via A2A."""
+
+import asyncio
+import httpx
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.artifacts import InMemoryArtifactService
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.sessions import InMemorySessionService
+from google.adk.runner import Runner
+from google.adk.tools.function_tool import FunctionTool
+from google.genai import types
+
+from a2a.client import (
+    A2AClient,
+    create_text_message_object,
+    MessageSendParams,
+    SendMessageRequest,
+)
+
+
+def perform_task(detail: str) -> str:
+    """Tool executed by the remote worker agent."""
+    return f"Task '{detail}' completed."
+
+
+# Worker agent definition (mirrors the remote server)
+worker_agent = LlmAgent(
+    name="worker_agent",
+    description="Handles delegated work.",
+    model=LiteLlm(model="openai/gpt-4o"),
+    instruction="Use perform_task to handle the request.",
+    tools=[perform_task],
+)
+
+
+async def delegate_via_a2a(task: str) -> str:
+    """Send a task to the worker agent via A2A."""
+    async with httpx.AsyncClient() as http_client:
+        client = A2AClient(httpx_client=http_client, url="http://localhost:8000/")
+        message = create_text_message_object(content=task, role="user")
+        params = MessageSendParams(message=message)
+        request = SendMessageRequest(params=params)
+        response = await client.send_message(request)
+        part = response.root.result.parts[0]
+        return part.text if hasattr(part, "text") else ""
+
+
+# Coordinator agent delegates tasks via the A2A tool
+delegate_tool = FunctionTool(func=delegate_via_a2a)
+coordinator = LlmAgent(
+    name="coordinator",
+    description="Delegates work to a remote worker using A2A.",
+    model=LiteLlm(model="openai/gpt-4o"),
+    instruction="Use the delegate_via_a2a tool whenever a user requests work.",
+    tools=[delegate_tool],
+)
+
+
+async def main() -> None:
+    session_service = InMemorySessionService()
+    artifact_service = InMemoryArtifactService()
+    runner = Runner(
+        app_name="a2a_demo",
+        agent=coordinator,
+        artifact_service=artifact_service,
+        session_service=session_service,
+    )
+    session = await session_service.create_session(app_name="a2a_demo", user_id="user")
+    user_message = types.Content(role="user", parts=[types.Part.from_text("demo task")])
+    async for event in runner.run_async(
+        user_id="user",
+        session_id=session.id,
+        new_message=user_message,
+    ):
+        if event.content.parts and hasattr(event.content.parts[0], "text"):
+            print(event.content.parts[0].text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
## Summary
- rewrite `multi_agent_a2a.py` to show a coordinator agent that uses a tool wrapping an A2A client
- the coordinator delegates work to a remote worker agent served by `a2a_adk_server.py`

## Testing
- `python -m py_compile multi_agent_a2a.py a2a_adk_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68410fb61cbc8332a47f998702de47a9