### PR TITLE
Add example usage for A2A utilities

### DIFF
--- a/samples/a2a_remote_agent/README.md
+++ b/samples/a2a_remote_agent/README.md
@@ -1,0 +1,15 @@
+# A2ARemoteAgent Example
+
+This sample shows how to wrap a remote A2A agent so it can be used with the
+Google ADK `Runner`.
+
+```bash
+# Install uv if you don't have it
+pip install uv
+
+# Install dependencies
+uv pip install google-adk a2a-sdk
+
+# Run the sample
+uv run sample.py
+```

--- a/samples/a2a_remote_agent/sample.py
+++ b/samples/a2a_remote_agent/sample.py
@@ -1,0 +1,23 @@
+import asyncio
+from adk_a2a_lib import A2ARemoteAgent
+from google.adk.artifacts import InMemoryArtifactService
+from google.adk.sessions import InMemorySessionService
+from google.adk.runner import Runner
+from google.genai import types
+
+async def main() -> None:
+    agent = await A2ARemoteAgent.from_url(name="remote", url="http://localhost:8000/")
+    runner = Runner(
+        app_name="remote_wrapper",
+        agent=agent,
+        artifact_service=InMemoryArtifactService(),
+        session_service=InMemorySessionService(),
+    )
+    session = await runner.session_service.create_session(app_name="remote_wrapper", user_id="user")
+    user_message = types.Content(role="user", parts=[types.Part.from_text("demo")])
+    async for event in runner.run_async(user_id="user", session_id=session.id, new_message=user_message):
+        if event.content and event.content.parts and hasattr(event.content.parts[0], "text"):
+            print(event.content.parts[0].text)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/a2a_tool/README.md
+++ b/samples/a2a_tool/README.md
@@ -1,0 +1,15 @@
+# A2ATool Example
+
+This sample shows how to delegate a task to a remote A2A agent using the
+`A2ATool` class.
+
+```bash
+# Install uv if you don't have it
+pip install uv
+
+# Install dependencies
+uv pip install google-adk a2a-sdk
+
+# Run the sample
+uv run sample.py
+```

--- a/samples/a2a_tool/sample.py
+++ b/samples/a2a_tool/sample.py
@@ -1,0 +1,11 @@
+import asyncio
+from adk_a2a_lib import A2ATool
+from google.adk.tools.tool_context import ToolContext
+
+async def main() -> None:
+    tool = await A2ATool.from_url(url="http://localhost:8000/")
+    result = await tool.run_async(args={"task": "demo"}, tool_context=ToolContext())
+    print(result)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/adk_a2a_lib/__init__.py
+++ b/src/adk_a2a_lib/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable library exposing ADK integration with A2A."""
+
+from .a2a_tool import A2ATool
+from .a2a_remote_agent import A2ARemoteAgent
+
+__all__ = ["A2ATool", "A2ARemoteAgent"]

--- a/src/adk_a2a_lib/a2a_remote_agent.py
+++ b/src/adk_a2a_lib/a2a_remote_agent.py
@@ -1,0 +1,53 @@
+"""A2ARemoteAgent: wrapper to use a remote A2A server as a sub-agent."""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+import httpx
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events import Event
+from typing_extensions import override
+
+from a2a.client import (
+    A2AClient,
+    create_text_message_object,
+    MessageSendParams,
+    SendMessageRequest,
+)
+
+
+class A2ARemoteAgent(BaseAgent):
+    """An ADK agent that delegates execution to a remote A2A agent."""
+
+    _client: A2AClient
+
+    def __init__(self, *, client: A2AClient, name: str, description: str = "Remote agent") -> None:
+        super().__init__(name=name, description=description)
+        self._client = client
+
+    @classmethod
+    async def from_url(cls, *, url: str, httpx_client: httpx.AsyncClient | None = None, name: str, description: str = "Remote agent") -> "A2ARemoteAgent":
+        httpx_client = httpx_client or httpx.AsyncClient()
+        client = A2AClient(httpx_client=httpx_client, url=url)
+        return cls(client=client, name=name, description=description)
+
+    @override
+    async def _run_async_impl(self, ctx: InvocationContext) -> AsyncGenerator[Event, None]:
+        user_parts = ctx.user_content.parts if ctx.user_content else []
+        text = user_parts[0].text if user_parts and hasattr(user_parts[0], "text") else ""
+
+        message = create_text_message_object(content=text, role="user")
+        params = MessageSendParams(message=message)
+        request = SendMessageRequest(params=params)
+        response = await self._client.send_message(request)
+        part = response.root.result.parts[0]
+        content_text = part.text if hasattr(part, "text") else ""
+        yield Event(invocation_id=ctx.invocation_id, author=self.name, branch=ctx.branch, content=ctx.user_content)
+        yield Event(
+            invocation_id=ctx.invocation_id,
+            author=self.name,
+            branch=ctx.branch,
+            content=create_text_message_object(role="agent", content=content_text),
+        )

--- a/src/adk_a2a_lib/a2a_tool.py
+++ b/src/adk_a2a_lib/a2a_tool.py
@@ -1,0 +1,47 @@
+"""A2ATool: ADK tool to delegate calls to a remote A2A agent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.tool_context import ToolContext
+from typing_extensions import override
+
+from a2a.client import (
+    A2AClient,
+    create_text_message_object,
+    MessageSendParams,
+    SendMessageRequest,
+)
+
+
+class A2ATool(BaseTool):
+    """Tool that sends a request to a remote A2A server."""
+
+    _client: A2AClient
+
+    def __init__(self, *, client: A2AClient, name: str = "a2a_tool", description: str = "Delegate to remote agent") -> None:
+        super().__init__(name=name, description=description)
+        self._client = client
+
+    @classmethod
+    async def from_url(cls, *, url: str, httpx_client: httpx.AsyncClient | None = None, name: str = "a2a_tool", description: str = "Delegate to remote agent") -> "A2ATool":
+        """Convenience initializer using just a URL."""
+        httpx_client = httpx_client or httpx.AsyncClient()
+        client = A2AClient(httpx_client=httpx_client, url=url)
+        return cls(client=client, name=name, description=description)
+
+    @override
+    async def run_async(self, *, args: dict[str, Any], tool_context: ToolContext) -> Any:
+        if not (content := args.get("task") or args.get("message") or args.get("input")):
+            raise ValueError("A2ATool requires a 'task', 'input', or 'message' argument")
+
+        message = create_text_message_object(content=content, role="user")
+        params = MessageSendParams(message=message)
+        request = SendMessageRequest(params=params)
+        response = await self._client.send_message(request)
+
+        part = response.root.result.parts[0]
+        return part.text if hasattr(part, "text") else ""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))

--- a/tests/test_a2a_lib.py
+++ b/tests/test_a2a_lib.py
@@ -1,0 +1,151 @@
+import sys
+import types
+import asyncio
+import pytest
+# stub httpx module
+httpx = types.ModuleType("httpx")
+class AsyncClient: pass
+httpx.AsyncClient = AsyncClient
+sys.modules.setdefault("httpx", httpx)
+
+
+# ---- Stub dependencies for google.adk ----
+class _BaseTool:
+    def __init__(self, *, name, description, is_long_running=False):
+        self.name = name
+        self.description = description
+        self.is_long_running = is_long_running
+
+class _ToolContext:
+    pass
+
+class _BaseAgent:
+    def __init__(self, *, name, description=""):
+        self.name = name
+        self.description = description
+
+class _InvocationContext:
+    def __init__(self, *, invocation_id, branch=None, user_content=None):
+        self.invocation_id = invocation_id
+        self.branch = branch
+        self.user_content = user_content
+
+class _Event:
+    def __init__(self, *, invocation_id, author, branch=None, content=None):
+        self.invocation_id = invocation_id
+        self.author = author
+        self.branch = branch
+        self.content = content
+
+# build google.adk package structure with minimal classes
+_google = types.ModuleType("google")
+_adk = types.ModuleType("google.adk")
+_tools = types.ModuleType("google.adk.tools")
+_tools_base = types.ModuleType("google.adk.tools.base_tool")
+_tools_ctx = types.ModuleType("google.adk.tools.tool_context")
+_agents = types.ModuleType("google.adk.agents")
+_agents_base = types.ModuleType("google.adk.agents.base_agent")
+_agents_ctx = types.ModuleType("google.adk.agents.invocation_context")
+_events_mod = types.ModuleType("google.adk.events")
+
+_tools_base.BaseTool = _BaseTool
+_tools_ctx.ToolContext = _ToolContext
+_agents_base.BaseAgent = _BaseAgent
+_agents_ctx.InvocationContext = _InvocationContext
+_events_mod.Event = _Event
+
+_google.adk = _adk
+_adk.tools = _tools
+_adk.agents = _agents
+_adk.events = _events_mod
+_tools.base_tool = _tools_base
+_tools.tool_context = _tools_ctx
+_agents.base_agent = _agents_base
+_agents.invocation_context = _agents_ctx
+
+sys.modules.setdefault("google", _google)
+sys.modules.setdefault("google.adk", _adk)
+sys.modules.setdefault("google.adk.tools", _tools)
+sys.modules.setdefault("google.adk.tools.base_tool", _tools_base)
+sys.modules.setdefault("google.adk.tools.tool_context", _tools_ctx)
+sys.modules.setdefault("google.adk.agents", _agents)
+sys.modules.setdefault("google.adk.agents.base_agent", _agents_base)
+sys.modules.setdefault("google.adk.agents.invocation_context", _agents_ctx)
+sys.modules.setdefault("google.adk.events", _events_mod)
+
+# ---- Stub dependencies for a2a ----
+class _FakeA2AClient:
+    def __init__(self, *, httpx_client=None, url=None):
+        self.httpx_client = httpx_client
+        self.url = url
+        self.sent_requests = []
+
+    async def send_message(self, request):
+        self.sent_requests.append(request)
+        return types.SimpleNamespace(
+            root=types.SimpleNamespace(
+                result=types.SimpleNamespace(
+                    parts=[types.SimpleNamespace(text="server reply")]
+                )
+            )
+        )
+
+def create_text_message_object(*, content="", role="user"):
+    return types.SimpleNamespace(role=role, parts=[types.SimpleNamespace(text=content)])
+
+class MessageSendParams:
+    def __init__(self, *, message):
+        self.message = message
+
+class SendMessageRequest:
+    def __init__(self, *, params):
+        self.params = params
+
+_a2a_client_mod = types.ModuleType("a2a.client")
+_a2a_client_mod.A2AClient = _FakeA2AClient
+_a2a_client_mod.create_text_message_object = create_text_message_object
+_a2a_client_mod.MessageSendParams = MessageSendParams
+_a2a_client_mod.SendMessageRequest = SendMessageRequest
+
+sys.modules.setdefault("a2a.client", _a2a_client_mod)
+
+# Import library after stubbing
+from adk_a2a_lib import A2ATool, A2ARemoteAgent
+
+
+@pytest.mark.asyncio
+async def test_a2a_tool_run_async():
+    client = _FakeA2AClient()
+    tool = A2ATool(client=client)
+    result = await tool.run_async(args={"task": "hello"}, tool_context=_ToolContext())
+    assert result == "server reply"
+    assert client.sent_requests[0].params.message.parts[0].text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_a2a_tool_missing_input():
+    tool = A2ATool(client=_FakeA2AClient())
+    with pytest.raises(ValueError):
+        await tool.run_async(args={}, tool_context=_ToolContext())
+
+
+@pytest.mark.asyncio
+async def test_a2a_tool_from_url():
+    httpx_client = object()
+    tool = await A2ATool.from_url(url="http://example.com", httpx_client=httpx_client)
+    assert isinstance(tool, A2ATool)
+    assert isinstance(tool._client, _FakeA2AClient)
+    assert tool._client.httpx_client is httpx_client
+    assert tool._client.url == "http://example.com"
+
+
+@pytest.mark.asyncio
+async def test_a2a_remote_agent_run_async_impl():
+    client = _FakeA2AClient()
+    agent = A2ARemoteAgent(client=client, name="remote")
+    user_content = create_text_message_object(content="hi", role="user")
+    ctx = _InvocationContext(invocation_id="123", branch="b1", user_content=user_content)
+    events = [e async for e in agent._run_async_impl(ctx)]
+    assert len(events) == 2
+    assert events[0].author == "remote"
+    assert events[1].content.parts[0].text == "server reply"


### PR DESCRIPTION
## Summary
- add `samples/` with usage demos for `A2ATool` and `A2ARemoteAgent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423ca32f4c83328fcec5f7cf33903f